### PR TITLE
Modified to accept new Instagram data format

### DIFF
--- a/src/app/extractor.js
+++ b/src/app/extractor.js
@@ -336,9 +336,8 @@ export async function extractData (files) {
         name: group.name,
         sentMessageCount: group.sentMessageCount
     }));
-
-    const followers = JSON.parse(await readFile('followers_and_following/followers.json'));
-    const allFollowers = followers.relationships_followers.map((f) => f.string_list_data[0]);
+    
+    const allFollowers = JSON.parse(await readFile('followers_and_following/followers.json')) ? JSON.parse(await readFile('followers_and_following/followers.json')).relationships_followers.map((f) => f.string_list_data[0]) : JSON.parse(await readFile('followers_and_following/followers_1.json')).map((f) => f.string_list_data[0]);
     const firstFollowerTimestamp = allFollowers.sort((a, b) => a.timestamp - b.timestamp)[0].timestamp;
     const formatDayDate = (date) => `${date.getDate().toString().padStart(2, '0')}/${(date.getMonth()+1).toString().padStart(2, '0')}/${date.getFullYear()}`;
     let followerCount = 0;

--- a/src/views/Loader.svelte
+++ b/src/views/Loader.svelte
@@ -38,10 +38,18 @@
             return;
         }
         const requiredFiles = [
-            'account_information/account_information.json'
+            'account_information/account_information.json',
+            'personal_information/account_information.json'
         ];
+        let foundRequiredFile = false;
         for (const requiredFile of requiredFiles) {
-            if (!files.some((file) => file.name === requiredFile)) return false;
+          if (files.some((file) => file.name === requiredFile)) {
+            foundRequiredFile = true;
+            break;
+          }
+        }
+        if (!foundRequiredFile) {
+          return false;
         }
         if (!validPackage) {
             error = 'Your package seems to be corrupted. Click or drop your package file here to retry';


### PR DESCRIPTION
Newer versions of the Instagram data package appear to have different formats than older ones, causing the program to hang on "Loading your package file..."
This pull request contains minor changes to fix two issues:

1. The `account_information.json` file is now stored in a different folder
2. `followers.json` has been renamed to `followers_1`.json and followers are no longer wrapped in the `relationships_followers` array

This is fixed by:

1. Checking whether the `account_information.json` exists in either of the two possible folders
2. Checking if `followers.json` exists, and if not, using `followers_1.json` instead, with a slightly different map statement.
