### PR TITLE
Filter out "You sent an attachment." from favourite words.

### DIFF
--- a/src/app/extractor.js
+++ b/src/app/extractor.js
@@ -317,7 +317,10 @@ export async function extractData(files) {
     extractedData.totalMessageCount = messages.length;
 
     const words = messages
-        .filter((message) => message.content)
+        .filter(
+            (message) =>
+                message.content && message.content !== 'You sent an attachment.'
+        )
         .map((message) => message.content.split(' '))
         .flat()
         .filter((w) => w.length > 5);


### PR DESCRIPTION
Title, for me my most used word was "attachment." and I don't think this is intended behaviour. There's probably more messages that should be filtered out, but that's the biggest one.